### PR TITLE
Add additional variables to credentials dict

### DIFF
--- a/osutils/__init__.py
+++ b/osutils/__init__.py
@@ -6,11 +6,14 @@ import re
 class OSNode( object ):
 
     credentials = dict(
+        region_name = os.environ.get('OS_REGION_NAME',''),
         username = os.environ.get('OS_USERNAME',''),
         password = os.environ.get('OS_PASSWORD',''),
         auth_url = os.environ.get('OS_AUTH_URL',''),
         project_id = os.environ.get('OS_PROJECT_ID',''),
-        user_domain_name = os.environ.get('OS_USER_DOMAIN_NAME','')
+        project_name = os.environ.get('OS_PROJECT_NAME',''),
+        user_domain_name = os.environ.get('OS_USER_DOMAIN_NAME',''),
+        project_domain_name = os.environ.get('OS_PROJECT_DOMAIN_NAME','')
     )
 
     def __init__( self ):


### PR DESCRIPTION
You can now use OS_PROJECT_NAME or OS_PROJECT_ID. This fixes #6.